### PR TITLE
Fix `usage` instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@ Generates a list of all grunt plugins as json and serves it via http.
 
 ## Usage
 
-node install
-node server.js
+```
+$ npm install
+$ node server.js
+```


### PR DESCRIPTION
2 little things:
- `node install` should be `npm install`
- Render the two commands on two lines.
